### PR TITLE
Allow to skip TTL checks.

### DIFF
--- a/fernet.go
+++ b/fernet.go
@@ -137,7 +137,7 @@ func genhmac(q, p, k []byte) {
 	h.Sum(q)
 }
 
-// Encrypts and signs msg with key k and returns the resulting
+// EncryptAndSign encrypts and signs msg with key k and returns the resulting
 // fernet token. If msg contains text, the text should be encoded
 // with UTF-8 to follow fernet convention.
 func EncryptAndSign(msg []byte, k *Key) (tok []byte, err error) {
@@ -152,9 +152,9 @@ func EncryptAndSign(msg []byte, k *Key) (tok []byte, err error) {
 	return tok, nil
 }
 
-// Verifies that tok is a valid fernet token that was signed with
-// a key in k at most ttl time ago. Returns the message contained
-// in tok if tok is valid, otherwise nil.
+// VerifyAndDecrypt verifies that tok is a valid fernet token that was signed
+// with a key in k at most ttl time ago only if ttl is greater than zero. 
+// Returns the message contained in tok if tok is valid, otherwise nil.
 func VerifyAndDecrypt(tok []byte, ttl time.Duration, k []*Key) (msg []byte) {
 	b := make([]byte, encoding.DecodedLen(len(tok)))
 	n, _ := encoding.Decode(b, tok)

--- a/fernet.go
+++ b/fernet.go
@@ -67,7 +67,7 @@ func verify(msg, tok []byte, ttl time.Duration, now time.Time, k *Key) []byte {
 		return nil
 	}
 	ts := time.Unix(int64(binary.BigEndian.Uint64(tok[1:])), 0)
-	if now.After(ts.Add(ttl)) || ts.After(now.Add(maxClockSkew)) {
+	if ttl >= 0 && (now.After(ts.Add(ttl)) || ts.After(now.Add(maxClockSkew))) {
 		return nil
 	}
 	n := len(tok) - sha256.Size

--- a/verify.json
+++ b/verify.json
@@ -5,5 +5,12 @@
     "ttl_sec": 60,
     "src": "hello",
     "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "token": "gAAAAAAdwJ6wAAECAwQFBgcICQoLDA0ODy021cpGVWKZ_eEwCGM4BLLF_5CV9dOPmrhuVUPgJobwOz7JcbmrR64jVmpU4IwqDA==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": -1,
+    "src": "hello",
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
   }
 ]


### PR DESCRIPTION
This allow to use fernet not just for message passing,
and for "long-term" encryption.

It will skip the TTL verification is the given TTL is not positive.