### PR TITLE
verify should only check ttl if > 0

### DIFF
--- a/fernet.go
+++ b/fernet.go
@@ -67,7 +67,7 @@ func verify(msg, tok []byte, ttl time.Duration, now time.Time, k *Key) []byte {
 		return nil
 	}
 	ts := time.Unix(int64(binary.BigEndian.Uint64(tok[1:])), 0)
-	if ttl >= 0 && (now.After(ts.Add(ttl)) || ts.After(now.Add(maxClockSkew))) {
+	if ttl > 0 && (now.After(ts.Add(ttl)) || ts.After(now.Add(maxClockSkew))) {
 		return nil
 	}
 	n := len(tok) - sha256.Size


### PR DESCRIPTION
The docs state the TTL is only checked during verify if > 0. This is similar to how Python does it too (well, Python checks if ttl is not None). I was trying to figure out what was wrong with my code, then realized it was because of this)!

If you think this should stay >= 0, then I am happy to update the docs!