### PR TITLE
Fix panic on verify on super short payload

### DIFF
--- a/fernet.go
+++ b/fernet.go
@@ -30,6 +30,7 @@ const (
 	payOffset         = ivOffset + aes.BlockSize
 	overhead          = 1 + 8 + aes.BlockSize + sha256.Size // ver + ts + iv + hmac
 	maxClockSkew      = 60 * time.Second
+	uint64Bytes       = 8
 )
 
 var encoding = base64.URLEncoding
@@ -63,7 +64,7 @@ func decodedLen(n int) int {
 
 // if msg is nil, decrypts in place and returns a slice of tok.
 func verify(msg, tok []byte, ttl time.Duration, now time.Time, k *Key) []byte {
-	if len(tok) < 1 || tok[0] != version {
+	if len(tok) < 1+uint64Bytes || tok[0] != version {
 		return nil
 	}
 	ts := time.Unix(int64(binary.BigEndian.Uint64(tok[1:])), 0)

--- a/invalid.json
+++ b/invalid.json
@@ -61,5 +61,12 @@
     "now": "1985-10-26T01:20:01-07:00",
     "ttl_sec": 0,
     "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "desc": "super short payload size",
+    "token": "gAAA",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 0,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
   }
 ]


### PR DESCRIPTION
When the base64 decoded payload is smaller than 9 bytes, we don't have
enough data to decode the uint64 timestamp, and will cause panic. This
change fixes that. Also add test case for that.

This is an example of panic/test failure, when changed the newly added
uint64Bytes to 1:

        fernet_test.go:73: test 9 super short payload size
        fernet_test.go:74: gAAA
    panic: runtime error: index out of range [7] with length 2 [recovered]
            panic: runtime error: index out of range [7] with length 2

    goroutine 20 [running]:
    testing.tRunner.func1.1(0x117e380, 0xc0000daa60)
            /usr/local/go/src/testing/testing.go:941 +0x3d0
    testing.tRunner.func1(0xc0000d0480)
            /usr/local/go/src/testing/testing.go:944 +0x3f9
    panic(0x117e380, 0xc0000daa60)
            /usr/local/go/src/runtime/panic.go:967 +0x166
    encoding/binary.bigEndian.Uint64(...)
            /usr/local/go/src/encoding/binary/binary.go:125
    github.com/fernet/fernet-go.verify(0x0, 0x0, 0x0, 0xc0000a67a0, 0x3, 0x3, 0x0, 0x0, 0xe955295b1, 0x12c4e00, ...)
            /Users/yuxuan.wang/work/fernet-go/fernet.go:70 +0x553
    github.com/fernet/fernet-go.TestVerifyBad(0xc0000d0480)
            /Users/yuxuan.wang/work/fernet-go/fernet_test.go:81 +0x39a
    testing.tRunner(0xc0000d0480, 0x119c1c0)
            /usr/local/go/src/testing/testing.go:992 +0xdc
    created by testing.(*T).Run
            /usr/local/go/src/testing/testing.go:1043 +0x357
    exit status 2
    FAIL    github.com/fernet/fernet-go     1.281s